### PR TITLE
fix newline handling logic

### DIFF
--- a/lib/em-twitter/connection.rb
+++ b/lib/em-twitter/connection.rb
@@ -137,10 +137,11 @@ module EventMachine
       protected
 
       def handle_stream(data)
+        @last_response << (@decoder ||= BaseDecoder.new).decode(data)
+
         # handle empty lines, Site stream sometimes returns \r\n\r\n
         return if data.strip.empty?
 
-        @last_response << (@decoder ||= BaseDecoder.new).decode(data)
         if @last_response.complete?
           invoke_callback(@client.each_item_callback, @last_response.body)
         end


### PR DESCRIPTION
Hi,
Newlines in stream must update @last_response.timestamp.
https://dev.twitter.com/docs/streaming-apis/messages#Blank_lines

This commit https://github.com/tweetstream/em-twitter/commit/470d7be82ca421118384397b36a6ff1c0c43f4e7 may invoke no_data_received in slow streams.
