### PR TITLE
Rename #respond_to argument variable.

### DIFF
--- a/lib/em-twitter/client.rb
+++ b/lib/em-twitter/client.rb
@@ -114,8 +114,8 @@ module EventMachine
         @connection.send(method, *args, &block)
       end
 
-      def respond_to?(method, include_private=false)
-        @connection.respond_to?(method, include_private) || super(method, include_private)
+      def respond_to?(method, include_all=false)
+        @connection.respond_to?(method, include_all) || super(method, include_all)
       end
 
       private


### PR DESCRIPTION
The second parameter stands for "if private and protected methods
are included", not just private methods, so `include_private` should
be renamed to `include_all`.
