### PR TITLE
the eventmachine 1.0.3 version is not able to be built on ruby 2.2

### DIFF
--- a/em-twitter.gemspec
+++ b/em-twitter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = %q{Twitter Streaming API client for EventMachine}
   spec.summary     = spec.description
 
-  spec.add_dependency 'eventmachine', '~> 1.0'
+  spec.add_dependency 'eventmachine', '~> 1.0.4'
   spec.add_dependency 'http_parser.rb', '~> 0.6'
   spec.add_dependency 'simple_oauth', '~> 0.2'
   spec.add_dependency 'buftok', '~> 0.2'


### PR DESCRIPTION
I wish to build `em-twitter` in my computer, but I got the same problem as [this](https://github.com/eventmachine/eventmachine/issues/553)  

After trying to upgrade the gem version to `1.0.4`, `em-twitter` works fine (At least in my project)